### PR TITLE
fix(tui): resolve component manager concurrency races

### DIFF
--- a/internal/tui/components/base.go
+++ b/internal/tui/components/base.go
@@ -4,6 +4,7 @@ package components
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/charmbracelet/bubbles/progress"
@@ -170,6 +171,7 @@ type PurgeResultMsg struct {
 
 // ComponentManager manages multiple components and their interactions.
 type ComponentManager struct {
+	mu         sync.RWMutex
 	components map[ViewState]Component
 	state      *SharedState
 	spinner    spinner.Model
@@ -216,11 +218,15 @@ func NewComponentManager(state *SharedState) *ComponentManager {
 
 // RegisterComponent registers a component for a specific view state.
 func (cm *ComponentManager) RegisterComponent(viewState ViewState, component Component) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
 	cm.components[viewState] = component
 }
 
 // GetComponent returns the component for a specific view state.
 func (cm *ComponentManager) GetComponent(viewState ViewState) Component {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
 	return cm.components[viewState]
 }
 
@@ -230,11 +236,13 @@ func (cm *ComponentManager) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		cm.progress.Width = msg.Width - 4
+		cm.mu.RLock()
 		for _, component := range cm.components {
 			if sizable, ok := component.(interface{ SetSize(int, int) }); ok {
 				sizable.SetSize(msg.Width, msg.Height)
 			}
 		}
+		cm.mu.RUnlock()
 		return cm, nil
 
 	case tea.KeyMsg:
@@ -256,7 +264,9 @@ func (cm *ComponentManager) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Delegate to current component
 	if component := cm.GetComponent(cm.state.ViewState); component != nil {
 		updatedComponent, cmd := component.Update(msg)
+		cm.mu.Lock()
 		cm.components[cm.state.ViewState] = updatedComponent
+		cm.mu.Unlock()
 		return cm, cmd
 	}
 

--- a/internal/tui/components/base.go
+++ b/internal/tui/components/base.go
@@ -235,14 +235,14 @@ func (cm *ComponentManager) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Handle global messages first
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
+		cm.mu.Lock()
+		defer cm.mu.Unlock()
 		cm.progress.Width = msg.Width - 4
-		cm.mu.RLock()
 		for _, component := range cm.components {
 			if sizable, ok := component.(interface{ SetSize(int, int) }); ok {
 				sizable.SetSize(msg.Width, msg.Height)
 			}
 		}
-		cm.mu.RUnlock()
 		return cm, nil
 
 	case tea.KeyMsg:
@@ -265,8 +265,8 @@ func (cm *ComponentManager) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if component := cm.GetComponent(cm.state.ViewState); component != nil {
 		updatedComponent, cmd := component.Update(msg)
 		cm.mu.Lock()
+		defer cm.mu.Unlock()
 		cm.components[cm.state.ViewState] = updatedComponent
-		cm.mu.Unlock()
 		return cm, cmd
 	}
 

--- a/internal/tui/components/base_test.go
+++ b/internal/tui/components/base_test.go
@@ -19,6 +19,8 @@ type mockComponent struct {
 	initCnt   int
 	focusCnt  int
 	blurCnt   int
+	width     int
+	height    int
 	mutex     sync.RWMutex
 }
 
@@ -61,6 +63,13 @@ func (m *mockComponent) IsFocused() bool {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 	return m.focused
+}
+
+func (m *mockComponent) SetSize(width, height int) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.width = width
+	m.height = height
 }
 
 func (m *mockComponent) getCounts() (int, int, int, int, int) {
@@ -310,6 +319,59 @@ func TestComponentManagerConcurrentAccess(t *testing.T) {
 	// Should not crash and should have valid state
 	if manager.state.ViewState != ViewMenu {
 		t.Error("Expected view state to remain ViewMenu")
+	}
+}
+
+func TestComponentManagerConcurrentMapAccessRegression(t *testing.T) {
+	memManager := memory.NewMemoryManager(1024) // 1GB
+	stateManager, err := state.NewStateManager("./test_state", "test-session")
+	if err != nil {
+		t.Fatalf("Failed to create state manager: %v", err)
+	}
+	defer stateManager.Close()
+	sharedState := &SharedState{
+		MemoryManager: memManager,
+		StateManager:  stateManager,
+		ViewState:     ViewMenu,
+		Config:        &config.Config{},
+	}
+	manager := NewComponentManager(sharedState)
+
+	component := &mockComponent{id: "component"}
+	manager.RegisterComponent(ViewMenu, component)
+
+	const iterations = 500
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(3)
+
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				manager.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				manager.View()
+			}
+		}()
+
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				manager.Update(tea.WindowSizeMsg{Width: 80 + j%5, Height: 24 + j%3})
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if manager.GetComponent(ViewMenu) == nil {
+		t.Fatal("Expected menu component to remain registered")
 	}
 }
 


### PR DESCRIPTION
## Summary

- add locking around ComponentManager component registration, lookup, resize iteration, and update replacement paths
- bring resize handling under the same manager lock so progress state updates are synchronised as well
- add a race-focused regression test covering concurrent update, view, and window-size traffic

## Testing

- go test ./internal/tui/components
- go test -race ./internal/tui/components
- go test ./...
